### PR TITLE
Remove invalid characters at the end of config.yaml

### DIFF
--- a/fsh/config.yaml
+++ b/fsh/config.yaml
@@ -46,4 +46,3 @@ pages:
     title: Discharge Medications
   downloads.md:
     title: Downloads
-		


### PR DESCRIPTION
There were some characters at the end of `fsh/config.yaml` that were causing YAML validation to fail with Ruby. This commit removes those characters.